### PR TITLE
[Fix] 페이지 라우팅 리다이렉트 문제 해결

### DIFF
--- a/src/components/common/ProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute.tsx
@@ -11,7 +11,7 @@ const ProtectedRoute = ({ element, path }: ProtectedRouteProps) => {
   const navigate = useNavigate();
 
   const isLoggedIn = async () => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem('access_token');
 
     if (!token) {
       return false;
@@ -47,7 +47,7 @@ const ProtectedRoute = ({ element, path }: ProtectedRouteProps) => {
     };
 
     checkLoggedIn();
-  }, []);
+  }, [path]);
 
   return element;
 };

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -10,7 +10,7 @@ const router = createBrowserRouter([
     children: [
       {
         index: true,
-        element: <ProtectedRoute element={<HomePage />} path="" />,
+        element: <HomePage />,
       },
       {
         path: 'signin',


### PR DESCRIPTION
<!-- PR 제목입니다. 우선은 커밋 컨벤션 따라갑시다! -->
<!-- [Feat] 어쩌구 저쩌구 -->
<!-- [Fix] 어쩌구 저쩌구 -->

## 📌 PR 타입

<!-- 해당하는 부분에 x 표시 해 주세요. -->

- [ ] Feature
- [x] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용

<!-- 작업 내용을 작성합니다 -->

- [ProtectedRoute 토큰 값 불러오지 못하는 문제 해결](https://github.com/jhsung23/pre-onboarding-12th-1-3/commit/f32d527d2129d4be59513bdd2312c09b04d09052)
- [[Fix] Homepage 페이지 ProtectedRoute 속성 제거](https://github.com/jhsung23/pre-onboarding-12th-1-3/commit/be69efdb09e0287ab675deeb9f447a12c3eb516e)

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)

<!-- 없다면 적지 않으셔도 됩니다. -->

기존 param 값의 변화로 useEffect 를 사용했다면 ([params]), 초기 페이지 렌더링시 리다이렉트 구현을 한번만 하면 되기에 빈 공백 ([]) 으로 리팩토링 하였음.
